### PR TITLE
Fix regex

### DIFF
--- a/lib/slim_migrations.rb
+++ b/lib/slim_migrations.rb
@@ -13,7 +13,7 @@ module Kernel
 
   # initialize migrations with <tt>migration do</tt> instead of <tt>class SomeMigration < ActiveRecord::Migration</tt>
   def migration(&block)
-    if caller[0].rindex(/(?:[0-9]+)_([_a-z0-9]*).rb:\d+(?::in `.*')?$/)
+    if caller[0].rindex(/\/(?:[0-9]+)_([_a-z0-9]*).rb:\d+(?::in `.*')?$/)
       m = Object.const_set $1.camelize, Class.new(ActiveRecord::Migration)
       m.class_eval(&block) # 3.1
     else


### PR DESCRIPTION
Previously the regex would be incorrect if the migration name included a digit and a underscore, e.g. 'add_foo1_to_products'.
